### PR TITLE
don't include sys/timeb.h now that ftime() is not used anymore

### DIFF
--- a/hdhomerun_os_posix.h
+++ b/hdhomerun_os_posix.h
@@ -30,7 +30,6 @@
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <sys/time.h>
-#include <sys/timeb.h>
 #include <sys/wait.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>

--- a/hdhomerun_os_windows.h
+++ b/hdhomerun_os_windows.h
@@ -44,7 +44,6 @@
 #include <signal.h>
 #include <time.h>
 #include <sys/types.h>
-#include <sys/timeb.h>
 
 #ifdef LIBHDHOMERUN_DLLEXPORT
 #define LIBHDHOMERUN_API __declspec(dllexport)


### PR DESCRIPTION
This silences related compiler warnings.

I'm happy to sign any Contributor License Agreement for this minimal contribution.
