### PR TITLE
Fix "warning C4800" on Windows MSVC build

### DIFF
--- a/hdhomerun_video.c
+++ b/hdhomerun_video.c
@@ -188,7 +188,7 @@ static void hdhomerun_video_stats_ts_pkt(struct hdhomerun_video_sock_t *vs, uint
 		return;
 	}
 
-	bool transport_error = ptr[1] >> 7;
+	bool transport_error = (ptr[1] & 0x80) != 0;
 	if (transport_error) {
 		vs->transport_error_count++;
 		vs->sequence[packet_identifier] = 0xFF;


### PR DESCRIPTION
When building on Win32 or Win64 MSVC compiler gives:
warning C4800: 'int' : forcing value to bool 'true' or 'false' (performance warning)
