### PR TITLE
add header include guard

### DIFF
--- a/hdhomerun.h
+++ b/hdhomerun.h
@@ -18,6 +18,8 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
+#ifndef HDHOMERUN_H
+#define HDHOMERUN_H
 #include "hdhomerun_os.h"
 #include "hdhomerun_types.h"
 #include "hdhomerun_pkt.h"
@@ -30,3 +32,4 @@
 #include "hdhomerun_channelscan.h"
 #include "hdhomerun_device.h"
 #include "hdhomerun_device_selector.h"
+#endif


### PR DESCRIPTION
Adds a header include guard to prevent multiple includes in a project.
Was considering just using a #pragma once define, but as libhdhomerun could potentially be compiled using any number of compilers, i believe this implementation is the more suitable for universal usage.