### PR TITLE
lower threshold for signal_present

### DIFF
--- a/hdhomerun_device.c
+++ b/hdhomerun_device.c
@@ -477,7 +477,7 @@ int hdhomerun_device_get_tuner_status(struct hdhomerun_device_t *hd, char **psta
 		status->raw_bits_per_second = hdhomerun_device_get_status_parse(status_str, "bps=");
 		status->packets_per_second = hdhomerun_device_get_status_parse(status_str, "pps=");
 
-		status->signal_present = status->signal_strength >= 45;
+		status->signal_present = status->signal_strength >= 30;
 
 		if (strcmp(status->lock_str, "none") != 0) {
 			if (status->lock_str[0] == '(') {
@@ -523,7 +523,7 @@ int hdhomerun_device_get_oob_status(struct hdhomerun_device_t *hd, char **pstatu
 
 		status->signal_strength = (unsigned int)hdhomerun_device_get_status_parse(status_str, "ss=");
 		status->signal_to_noise_quality = (unsigned int)hdhomerun_device_get_status_parse(status_str, "snq=");
-		status->signal_present = status->signal_strength >= 45;
+		status->signal_present = status->signal_strength >= 30;
 		status->lock_supported = (strcmp(status->lock_str, "none") != 0);
 	}
 


### PR DESCRIPTION
I have a low powered station that wasn't being picked up when doing a
full scan using the command `hdhomerun_config FFFFFFFF scan /tuner0`.

Here is the channel info:
```
$ hdhomerun_config FFFFFFFF set /tuner0/channel auto:41
$ hdhomerun_config FFFFFFFF get /tuner0/status
ch=auto:41 lock=8vsb ss=37 snq=60 seq=100 bps=19636224 pps=0
$ hdhomerun_config FFFFFFFF get /tuner0/streaminfo
1: 60.1 W41DO-D
2: 60.2 HSN2-HD
tsid=0x0001
```