### PR TITLE
add hdhomerun_device_upgrade_filename helper

### DIFF
--- a/hdhomerun_device.c
+++ b/hdhomerun_device.c
@@ -1322,6 +1322,17 @@ int hdhomerun_device_upgrade(struct hdhomerun_device_t *hd, FILE *upgrade_file)
 	return hdhomerun_control_upgrade(hd->cs, upgrade_file);
 }
 
+int hdhomerun_device_upgrade_filename(struct hdhomerun_device_t *hd, char *filename)
+{
+  int ret;
+  FILE *fp = fopen(filename, "rb");
+  if (!fp)
+      return -1;
+  ret = hdhomerun_device_upgrade(hd, fp);
+  fclose(fp);
+  return ret;
+}
+
 void hdhomerun_device_debug_print_video_stats(struct hdhomerun_device_t *hd)
 {
 	if (!hdhomerun_debug_enabled(hd->dbg)) {

--- a/hdhomerun_device.h
+++ b/hdhomerun_device.h
@@ -239,6 +239,7 @@ extern LIBHDHOMERUN_API uint8_t hdhomerun_device_channelscan_get_progress(struct
  * Returns -1 if an error occurs.
  */
 extern LIBHDHOMERUN_API int hdhomerun_device_upgrade(struct hdhomerun_device_t *hd, FILE *upgrade_file);
+extern LIBHDHOMERUN_API int hdhomerun_device_upgrade_filename(struct hdhomerun_device_t *hd, char *filename);
 
 /*
  * Low level accessor functions. 


### PR DESCRIPTION
This makes it easier to issue firmware upgrades from FFI wrappers in higher-level languages where creating a FILE* handle might be tricky.