### PR TITLE
Add some missing types

### DIFF
--- a/hdhomerun_types.h
+++ b/hdhomerun_types.h
@@ -25,6 +25,8 @@
 
 struct hdhomerun_device_t;
 struct hdhomerun_device_allocation_t;
+struct hdhomerun_device_selector_t;
+struct hdhomerun_discover_t;
 
 struct hdhomerun_tuner_status_t {
 	char channel[32];


### PR DESCRIPTION
These types are references in other headers but never defined anywhere, which can cause problems for some FFI wrapper autogen scripts.