### PR TITLE
Alignas on posix failing under Gcc 8.3.0

### DIFF
--- a/hdhomerun_os_posix.h
+++ b/hdhomerun_os_posix.h
@@ -53,7 +53,7 @@ typedef struct {
 
 #define LIBHDHOMERUN_API
 
-#if !defined(alignas)
+#if !defined(alignas) && !defined(__cplusplus)
 #define alignas(n) __attribute__((aligned(n)))
 #endif
 


### PR DESCRIPTION
alignas is a keyword in c++. Dont define.
Change is in windows header already, and GCC 8.3.0 is erroring on this now.

hd_homerun_windows_os.h already handles the definition this way.

https://gcc.gnu.org/bugzilla/show_bug.cgi?id=89464