### PR TITLE
Thread handle leak in hdhomerun_os_windows

### DIFF
--- a/hdhomerun_os_windows.c
+++ b/hdhomerun_os_windows.c
@@ -113,6 +113,7 @@ void thread_task_join(thread_task_t tid)
 			return;
 		}
 		if (ExitCode != STILL_ACTIVE) {
+			CloseHandle(tid);
 			return;
 		}
 	}


### PR DESCRIPTION
The thread handle being created in thread_task_create is never closed after the thread has been successfully joined with thread_task_join.