### PR TITLE
Use RtlGenRandom when available to eliminate TLS and heap leaks

### DIFF
--- a/hdhomerun_os_windows.c
+++ b/hdhomerun_os_windows.c
@@ -20,34 +20,16 @@
 
 #include "hdhomerun.h"
 
-#if defined(_WINRT)
 uint32_t random_get32(void)
 {
-	return (uint32_t)getcurrenttime();
-}
-#else
-uint32_t random_get32(void)
-{
-	static DWORD random_get32_context_tls = 0xFFFFFFFF;
-	if (random_get32_context_tls == 0xFFFFFFFF) {
-		random_get32_context_tls = TlsAlloc();
-	}
+	uint32_t Result = (uint32_t)getcurrenttime();
 
-	HCRYPTPROV *phProv = (HCRYPTPROV *)TlsGetValue(random_get32_context_tls);
-	if (!phProv) {
-		phProv = (HCRYPTPROV *)calloc(1, sizeof(HCRYPTPROV));
-		CryptAcquireContext(phProv, 0, 0, PROV_RSA_FULL, CRYPT_VERIFYCONTEXT);
-		TlsSetValue(random_get32_context_tls, phProv);
-	}
-
-	uint32_t Result;
-	if (!CryptGenRandom(*phProv, sizeof(Result), (BYTE *)&Result)) {
-		return (uint32_t)getcurrenttime();
-	}
+#if defined(RtlGenRandom)
+	RtlGenRandom(&Result, sizeof(Result));
+#endif
 
 	return Result;
 }
-#endif
 
 uint64_t getcurrenttime(void)
 {

--- a/hdhomerun_os_windows.h
+++ b/hdhomerun_os_windows.h
@@ -46,6 +46,10 @@
 #include <time.h>
 #include <sys/types.h>
 
+#define SystemFunction036 NTAPI SystemFunction036
+#include <ntsecapi.h>
+#undef SystemFunction036
+
 #ifdef LIBHDHOMERUN_DLLEXPORT
 #define LIBHDHOMERUN_API __declspec(dllexport)
 #endif


### PR DESCRIPTION
The implementation of random_get32 in hdhomerun_os_windows.c leaks all sorts of things:

- The TLS slot
- The heap memory allocated for the HCRYPTPROV handle
- The HCRYPTPROV handle itself

There is a function available in Desktop Windows since XP, RtlGenRandom(), that can perform the same operation without needing all of these things.  The function is a little odd since it's actually called SystemFunction036 but Microsoft has dealt with this in the SDK headers so no tricks are necessary.

The proposed change simplifies the code, avoids the various leaks, and if the platform / SDK version doesn't support the RtlGenRandom macro the function will fall back to getcurrenttime() as it would for WINRT or if an error occurred.