### PR TITLE
Set US antenna channels scan to stop at RF36

### DIFF
--- a/hdhomerun_channels.c
+++ b/hdhomerun_channels.c
@@ -95,7 +95,7 @@ static const struct hdhomerun_channelmap_range_t hdhomerun_channelmap_range_us_b
 	{  2,   4,  57000000, 6000000},
 	{  5,   6,  79000000, 6000000},
 	{  7,  13, 177000000, 6000000},
-	{ 14,  69, 473000000, 6000000},
+	{ 14,  36, 473000000, 6000000},
 	{  0,   0,         0,       0}
 };
 


### PR DESCRIPTION
Now that the FCC Channel Repack is complete, the upper limit for TV channels is now 36. This will also reduce scan times.