### PR TITLE
Fix usage of nlmsg_len

### DIFF
--- a/hdhomerun_sock_netlink.c
+++ b/hdhomerun_sock_netlink.c
@@ -147,12 +147,12 @@ bool hdhomerun_local_ip_info2(int af, hdhomerun_local_ip_info2_callback_t callba
 
 	struct nlmsghdr_ifaddrmsg req;
 	memset(&req, 0, sizeof(req));
-	req.nlh.nlmsg_len = NLMSG_ALIGN(NLMSG_LENGTH(sizeof(req)));
+	req.nlh.nlmsg_len = NLMSG_LENGTH(sizeof(req));
 	req.nlh.nlmsg_type = RTM_GETADDR;
 	req.nlh.nlmsg_flags = NLM_F_REQUEST | NLM_F_MATCH;
 	req.msg.ifa_family = af;
 
-	if (send(nl_sock, &req, req.nlh.nlmsg_len, 0) != (ssize_t)req.nlh.nlmsg_len) {
+	if (send(nl_sock, &req, sizeof(req), 0) != sizeof(req)) {
 		close(af_sock);
 		close(nl_sock);
 		free(nl_buffer);


### PR DESCRIPTION
- `nlmsg_len` should be set directly to the output of `NLMSG_LENGTH` (doesn't change anything in practice but it's better to use the intended way)
- pass the correct size to `send(2)`, this avoids out of bounds memory access